### PR TITLE
feat : 게임 시작 버튼 구현

### DIFF
--- a/Assets/InputSystem_Actions.inputactions
+++ b/Assets/InputSystem_Actions.inputactions
@@ -1,4 +1,5 @@
 {
+    "version": 1,
     "name": "InputSystem_Actions",
     "maps": [
         {

--- a/Assets/Scripts/Lobby/LobbyUIController.cs
+++ b/Assets/Scripts/Lobby/LobbyUIController.cs
@@ -2,16 +2,15 @@ using UnityEngine;
 
 public class LobbyUIController : MonoBehaviour
 {
-    public GameObject SceneLoader;
     public Transform CanvasTransform;
     public void init()
     {
-        //UIManager.Instance.CurrencyUI.SetActive(true);
+        UIManager.Instance.CurrencyUI.SetActive(true);
     }
 
     private void Update()
     {
-        //HandleInput();
+        HandleInput();
     }
 
     private void HandleInput()
@@ -20,21 +19,21 @@ public class LobbyUIController : MonoBehaviour
         {
             //AudioManager.Instance.Play(AudioType.SFX, "ui_button_click");
 
-        /*    var frontUI = UIManager.Instance.GetFrontUI();
+            var frontUI = UIManager.Instance.GetFrontUI();
             if (frontUI != null)
             {
                 frontUI.Close();
             }
             else
             {
-                ShowQuitConfirmUI();
-            }*/
+                //ShowQuitConfirmUI();
+            }
         }
     }
 
-    private void ShowQuitConfirmUI()
+    /*private void ShowQuitConfirmUI()
     {
-        /*var data = new ConfirmUIData()
+        var data = new ConfirmUIData()
         {
             ConfirmType = EConfirmType.OK_CANCEL,
             TitleText = "Quit",
@@ -43,8 +42,8 @@ public class LobbyUIController : MonoBehaviour
             CancleButtonText = "Cancle",
             ActionOnClickOKButton = () => Application.Quit()
         };
-        UIManager.Instance.OpenUI<ConfirmUI>(data);*/
-    }
+        UIManager.Instance.OpenUI<ConfirmUI>(data);
+    }*/
 
     public void OnClickSettingsButton()
     {
@@ -57,12 +56,7 @@ public class LobbyUIController : MonoBehaviour
     public void OnClickMissionShopButton()
     {
         Debug.Log($"{GetType()}::{nameof(OnClickMissionShopButton)}");
-        /*var ui = Resources.Load<BaseUI>("UI/ShopUI");
-        var result = Instantiate(ui);
-        result.gameObject.SetActive(true);
-        result.transform.SetParent(CanvasTransform);
-        result.transform.SetSiblingIndex(CanvasTransform.childCount - 1);
-        result.Init(CanvasTransform);*/
+
         var uiData = new BaseUIData();
         UIManager.Instance.OpenUI<MissionShopUI>(uiData);
     }
@@ -70,6 +64,6 @@ public class LobbyUIController : MonoBehaviour
     public void OnClickStartButton()
     {
         Debug.Log($"{GetType()}::{nameof(OnClickStartButton)}");
-        //SceneLoader.Instance.LoadScene(ESceneType.InGame);
+        SceneLoader.Instance.LoadScene(ESceneType.InGame);
     }
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -11,6 +11,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Lobby.unity
     guid: 479be082f60bfcd4196923c7f40a23d2
+  - enabled: 1
+    path: Assets/Scenes/InGame.unity
+    guid: 3327ed6a8b25fd546aa3ca04a527abd2
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 2bcd2660ca9b64942af0de543d8d7100, type: 3}
   m_UseUCBPForAssetBundles: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -768,7 +768,7 @@ PlayerSettings:
   qnxGraphicConfPath: 
   apiCompatibilityLevel: 6
   captureStartupLogs: {}
-  activeInputHandler: 1
+  activeInputHandler: 2
   windowsGamepadBackendHint: 0
   cloudProjectId: 19062b80-d947-4bc7-b90d-752630550ec0
   framebufferDepthMemorylessMode: 0


### PR DESCRIPTION
### 🔍 개요

- 게임 시작을 버튼 구현
- close #9

---

### 🚀 주요 변경 내용

- Lobby 화면의 '게임 시작' 버튼을 누르면 InGame 씬으로 넘어간다.
- 주석 처리된 부분을 다시 원래대로 복귀
- 인풋 시스템만 사용에서 Both(인풋 시스템 & 인풋 매니저)로 변경

---

### 💬 참고 사항

- 관련 GIF
![2025-09-21 00-07-31](https://github.com/user-attachments/assets/959496bf-3b68-45e1-bacb-db3cddc150b4)

---

### ✅ Checklist (완료 조건)

- [X] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [X] 기획서의 내용을 준수했는가?
