### PR TITLE
bugfix : 상점 페이지 텍스트 수정 & bugfix : ShopUI 판매 캐릭터 이미지 크기 조정 & refactor ShopUI.cs 최적화 :  

### DIFF
--- a/Assets/Prefabs/Lobby/ShopUI.prefab
+++ b/Assets/Prefabs/Lobby/ShopUI.prefab
@@ -1843,7 +1843,7 @@ RectTransform:
   m_GameObject: {fileID: 3900716684236921774}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 8, y: 8, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 687218658436355542}
@@ -1851,7 +1851,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 300, y: 300}
+  m_SizeDelta: {x: 21, y: 46}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8237438869189399176
 CanvasRenderer:
@@ -4206,7 +4206,7 @@ RectTransform:
   m_GameObject: {fileID: 7916172617338895990}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 8, y: 8, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6695148789926462303}
@@ -4214,7 +4214,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 300, y: 300}
+  m_SizeDelta: {x: 43, y: 42}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6522464634517333417
 CanvasRenderer:

--- a/Assets/Prefabs/Lobby/ShopUI.prefab
+++ b/Assets/Prefabs/Lobby/ShopUI.prefab
@@ -4016,19 +4016,35 @@ MonoBehaviour:
   GoldShopUI: {fileID: 2926704367083547641}
   pageText: {fileID: 502969720841508392}
   left_SaleCharacterImage: {fileID: 4592630310713699018}
-  right_SaleCharacterImage: {fileID: 2951314785548876138}
   leftCharacterName: {fileID: 600229948947637650}
-  rightCharacterName: {fileID: 12123699642426327}
   leftSkillName: {fileID: 3073605000378948389}
-  rightSkillName: {fileID: 3524623317807374231}
   leftSkillDetail: {fileID: 3824268797697096694}
-  rightSkillDetail: {fileID: 8778903413004030684}
   leftCharacterPrice: {fileID: 7485693403740802962}
-  rightCharacterPrice: {fileID: 6281777166104030582}
   leftCharacterBuyBtn: {fileID: 2820882424870596749}
-  rightCharacterBuyBtn: {fileID: 7359921985251237933}
   leftSoldOutMarker: {fileID: 1586325187713514343}
+  right_SaleCharacterImage: {fileID: 2951314785548876138}
+  rightCharacterName: {fileID: 12123699642426327}
+  rightSkillName: {fileID: 3524623317807374231}
+  rightSkillDetail: {fileID: 8778903413004030684}
+  rightCharacterPrice: {fileID: 6281777166104030582}
+  rightCharacterBuyBtn: {fileID: 7359921985251237933}
   rightSoldOutMarker: {fileID: 5879892257633179896}
+  leftCSPanel:
+    saleCharacterImage: {fileID: 4592630310713699018}
+    characterName: {fileID: 600229948947637650}
+    skillName: {fileID: 3073605000378948389}
+    skillDetail: {fileID: 3824268797697096694}
+    characterPrice: {fileID: 7485693403740802962}
+    characterBuyBtn: {fileID: 2820882424870596749}
+    soldOutMarker: {fileID: 1586325187713514343}
+  rightCSPanel:
+    saleCharacterImage: {fileID: 2951314785548876138}
+    characterName: {fileID: 12123699642426327}
+    skillName: {fileID: 3524623317807374231}
+    skillDetail: {fileID: 8778903413004030684}
+    characterPrice: {fileID: 6281777166104030582}
+    characterBuyBtn: {fileID: 7359921985251237933}
+    soldOutMarker: {fileID: 5879892257633179896}
 --- !u!1 &7911536598438081930
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/UI/ShopUI.cs
+++ b/Assets/Scripts/Common/UI/ShopUI.cs
@@ -24,6 +24,7 @@ public class ShopUI : BaseUI
     [SerializeField] private TextMeshProUGUI pageText;
 
     private int currentPageIndex = 0;
+    private int maxCharPageIndex;
 
     // 각 페이지에 해당하는 캐릭터 정보를 표현하는 변수
     [SerializeField] private Image left_SaleCharacterImage;
@@ -48,6 +49,7 @@ public class ShopUI : BaseUI
         _characterModel = DataTableManager.Instance.GetAllCharacterModelData();
         _userCharacterData = UserDataManager.Instance.GetUserData<UserCharacterData>();
 
+        maxCharPageIndex = _characterModel.Length / 2;
         Debug.Log($"현재 보유한 캐릭터 수 : {_userCharacterData.acuiredChatacter.Count}");
         foreach (var Id in _userCharacterData.acuiredChatacter)
         {
@@ -198,6 +200,9 @@ public class ShopUI : BaseUI
             rightText = _characterModel[index + 1].Price.ToString();
         }
         rightCharacterPrice.text = rightText;
+
+        left_SaleCharacterImage.SetNativeSize();
+        right_SaleCharacterImage.SetNativeSize();
     }
 
 }

--- a/Assets/Scripts/Common/UI/ShopUI.cs
+++ b/Assets/Scripts/Common/UI/ShopUI.cs
@@ -116,7 +116,7 @@ public class ShopUI : BaseUI
 
     private void UpdatePageNumText()
     {
-        pageText.text = currentPageIndex.ToString();
+        pageText.text = (currentPageIndex + 1).ToString();
     }
 
     public void UpdateCurrentPageData()

--- a/Assets/Scripts/Common/UI/ShopUI.cs
+++ b/Assets/Scripts/Common/UI/ShopUI.cs
@@ -1,15 +1,28 @@
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using System;
-using System.Linq;
 
-public class ShopUIData : BaseUIData
+[Serializable]
+public struct CharacterSalePanel
 {
-    //public bool IsPossesed { get; set; }
+    //판매 캐릭터 정보
+    public Image saleCharacterImage;
+    [Space(10f)]
+    public TextMeshProUGUI characterName;
+    [Space(10f)]
+    public TextMeshProUGUI skillName;
+    public TextMeshProUGUI skillDetail;
+    [Space(10f)]
+    public TextMeshProUGUI characterPrice;
+    [Space(10f)]
+    public Button characterBuyBtn;
+    [Space(10f)]
+    // 구매 완료 표시 오브젝트
+    public GameObject soldOutMarker;
+
 }
+
 public class ShopUI : BaseUI
 {
     // 캐릭터 정보 
@@ -19,37 +32,30 @@ public class ShopUI : BaseUI
     private UserCharacterData _userCharacterData;
 
     // 페이지 전환 관련
+    [Header("Page Change UI")]
     [SerializeField] private GameObject CharShopUI;
     [SerializeField] private GameObject GoldShopUI;
+
+    [Header("PageIndex Text")]
     [SerializeField] private TextMeshProUGUI pageText;
 
     private int currentPageIndex = 0;
-    private int maxCharPageIndex;
+    private int maxPageIndex;
 
-    // 각 페이지에 해당하는 캐릭터 정보를 표현하는 변수
-    [SerializeField] private Image left_SaleCharacterImage;
-    [SerializeField] private Image right_SaleCharacterImage;
-    [SerializeField] private TextMeshProUGUI leftCharacterName;
-    [SerializeField] private TextMeshProUGUI rightCharacterName;
-    [SerializeField] private TextMeshProUGUI leftSkillName;
-    [SerializeField] private TextMeshProUGUI rightSkillName;
-    [SerializeField] private TextMeshProUGUI leftSkillDetail;
-    [SerializeField] private TextMeshProUGUI rightSkillDetail;
-    [SerializeField] private TextMeshProUGUI leftCharacterPrice;
-    [SerializeField] private TextMeshProUGUI rightCharacterPrice;
-    [SerializeField] private Button leftCharacterBuyBtn;
-    [SerializeField] private Button rightCharacterBuyBtn;
+    [Header("Left Character Sale Panel")]
+    public CharacterSalePanel leftCSPanel;
 
-    // 보유 중인 캐릭터를 사용자에게 보여주기 위한 오브젝트
-    [SerializeField] private GameObject leftSoldOutMarker;
-    [SerializeField] private GameObject rightSoldOutMarker;
+    [Header("Right Character Sale Panel")]
+    public CharacterSalePanel rightCSPanel;
+
 
     private void Awake()
     {
         _characterModel = DataTableManager.Instance.GetAllCharacterModelData();
         _userCharacterData = UserDataManager.Instance.GetUserData<UserCharacterData>();
 
-        maxCharPageIndex = _characterModel.Length / 2;
+        maxPageIndex = _characterModel.Length / 2;
+
         Debug.Log($"현재 보유한 캐릭터 수 : {_userCharacterData.acuiredChatacter.Count}");
         foreach (var Id in _userCharacterData.acuiredChatacter)
         {
@@ -66,7 +72,7 @@ public class ShopUI : BaseUI
 
     public void ShowGoldPage()
     {
-        currentPageIndex = _characterModel.Length / 2;
+        currentPageIndex = maxPageIndex;
         GoldShopUI.SetActive(true);
         CharShopUI.SetActive(false);
         UpdatePageNumText();
@@ -75,7 +81,7 @@ public class ShopUI : BaseUI
     public void OnClickLeftPageBtn()
     {
         Debug.Log($"현재 CurrentPageIndex : {currentPageIndex}");
-        if (currentPageIndex == _characterModel.Length / 2)
+        if (currentPageIndex ==  maxPageIndex)
         {
             Debug.Log("현재 페이지는 골드 페이지 입니다. 캐릭터 페이지로 전환합니다.");
             GoldShopUI.SetActive(false);
@@ -95,12 +101,12 @@ public class ShopUI : BaseUI
 
     public void OnClickRightPageBtn()
     {
-        if (currentPageIndex >= _characterModel.Length / 2)
+        if (currentPageIndex >= maxPageIndex)
         {
             Debug.Log("최대 페이지 입니다.");
             return;
         }
-        else if (currentPageIndex >= (_characterModel.Length / 2) -1)
+        else if (currentPageIndex >= (maxPageIndex) -1)
         {
             Debug.Log("현재 페이지는 캐릭터 페이지입니다. 골드 페이지로 전환합니다.");
             CharShopUI.SetActive(false);
@@ -134,75 +140,76 @@ public class ShopUI : BaseUI
         Debug.Log($"좌측 캐릭터 ID : {_characterModel[index].ID}");
         Debug.Log($"우측 캐릭터 ID : {_characterModel[index+1].ID}");
 
-        left_SaleCharacterImage.sprite = Resources.Load<Sprite>($"Textures/{_characterModel[index].ID}");
-        right_SaleCharacterImage.sprite = Resources.Load<Sprite>($"Textures/{_characterModel[index + 1].ID}");
+        // left Character Sale panel
+        leftCSPanel.saleCharacterImage.sprite = Resources.Load<Sprite>($"Textures/{_characterModel[index].ID}");
+        leftCSPanel.characterName.text = _characterModel[index].Name;
+        leftCSPanel.skillName.text = _characterModel[index].SkillName;
+        leftCSPanel.skillDetail.text = _characterModel[index].SkillDescription;
+        leftCSPanel.characterBuyBtn.GetComponent<BuyBtnOfChar>().Char_Id = _characterModel[index].ID;
 
-        leftCharacterName.text = _characterModel[index].Name;
-        rightCharacterName.text = _characterModel[index + 1].Name;
+        //right Character Sale panel
+        rightCSPanel.saleCharacterImage.sprite = Resources.Load<Sprite>($"Textures/{_characterModel[index + 1].ID}");
+        rightCSPanel.characterName.text = _characterModel[index + 1].Name;
+        rightCSPanel.skillName.text = _characterModel[index + 1].SkillName;
+        rightCSPanel.skillDetail.text = _characterModel[index + 1].SkillDescription;
+        rightCSPanel.characterBuyBtn.GetComponent<BuyBtnOfChar>().Char_Id = _characterModel[index + 1].ID;
 
-        leftSkillName.text = _characterModel[index].SkillName;
-        rightSkillName.text = _characterModel[index + 1].SkillName;
-
-        leftSkillDetail.text = _characterModel[index].SkillDescription;
-        rightSkillDetail.text = _characterModel[index + 1].SkillDescription;
-
-        leftCharacterBuyBtn.GetComponent<BuyBtnOfChar>().Char_Id = _characterModel[index].ID;
-        rightCharacterBuyBtn.GetComponent<BuyBtnOfChar>().Char_Id = _characterModel[index+1].ID;
 
         // 구매 버튼에 들어갈 색상, 텍스트 설정
         Color color = new Color(1, 1, 1, 0.3f);
-        string leftText = "";
-        string rightText = "";
 
         if (_userCharacterData.CharacterID_InUse == _characterModel[index].ID)
         {
-            leftCharacterBuyBtn.interactable = false;
-            leftCharacterBuyBtn.image.color = color;
-            leftSoldOutMarker.SetActive(true);
-            leftText = "선택중";
+            leftCSPanel.characterBuyBtn.interactable = false;
+            leftCSPanel.characterBuyBtn.image.color = color;
+            leftCSPanel.soldOutMarker.SetActive(true);
+
+            leftCSPanel.characterPrice.text = "선택중";
         }
         else if (_userCharacterData.acuiredChatacter.Contains(_characterModel[index].ID))
         {
-            leftCharacterBuyBtn.interactable = true;
-            leftSoldOutMarker.SetActive(true);
-            leftCharacterBuyBtn.image.color = Color.white;
-            leftText = "보유중";
+            leftCSPanel.characterBuyBtn.interactable = true;
+            leftCSPanel.soldOutMarker.SetActive(true);
+            leftCSPanel.characterBuyBtn.image.color = Color.white;
+
+            leftCSPanel.characterPrice.text = "보유중";
         }
         else
         {
-            leftCharacterBuyBtn.interactable = true;
-            leftCharacterBuyBtn.image.color = Color.white;
-            leftSoldOutMarker.SetActive(false);
-            leftText = _characterModel[index].Price.ToString();
+            leftCSPanel.characterBuyBtn.interactable = true;
+            leftCSPanel.characterBuyBtn.image.color = Color.white;
+            leftCSPanel.soldOutMarker.SetActive(false);
+            leftCSPanel.characterPrice.text = _characterModel[index].Price.ToString();
         }
-        leftCharacterPrice.text = leftText;
 
 
         if (_userCharacterData.CharacterID_InUse == _characterModel[index + 1].ID)
         {
-            rightCharacterBuyBtn.interactable = false;
-            rightCharacterBuyBtn.image.color = color;
-            rightSoldOutMarker.SetActive(true);
-            rightText = "선택중";
+            rightCSPanel.characterBuyBtn.interactable = false;
+            rightCSPanel.characterBuyBtn.image.color = color;
+            rightCSPanel.soldOutMarker.SetActive(true);
+
+            rightCSPanel.characterPrice.text = "선택중";
         }
         else if (_userCharacterData.acuiredChatacter.Contains(_characterModel[index + 1].ID))
         {
-            rightCharacterBuyBtn.interactable = true;
-            rightSoldOutMarker.SetActive(true);
-            rightCharacterBuyBtn.image.color = Color.white;
-            rightText = "보유중";
+            rightCSPanel.characterBuyBtn.interactable = true;
+            rightCSPanel.soldOutMarker.SetActive(true);
+            rightCSPanel.characterBuyBtn.image.color = Color.white;
+
+            rightCSPanel.characterPrice.text = "보유중";
         }
         else
         {
-            rightCharacterBuyBtn.interactable = true;
-            rightCharacterBuyBtn.image.color = Color.white;
-            rightSoldOutMarker.SetActive(false);
-            rightText = _characterModel[index + 1].Price.ToString();
-        }
-        rightCharacterPrice.text = rightText;
+            rightCSPanel.characterBuyBtn.interactable = true;
+            rightCSPanel.characterBuyBtn.image.color = Color.white;
+            rightCSPanel.soldOutMarker.SetActive(false);
 
-        left_SaleCharacterImage.SetNativeSize();
-        right_SaleCharacterImage.SetNativeSize();
+            rightCSPanel.characterPrice.text = _characterModel[index + 1].Price.ToString();
+        }
+
+        leftCSPanel.saleCharacterImage.SetNativeSize();
+        rightCSPanel.saleCharacterImage.SetNativeSize();
     }
 
 }


### PR DESCRIPTION
### 🔍 개요

- 상점 페이지 번호가 1부터 시작되도록 구현
- ShopUI에서 판매 캐릭터의 이미지 크기를 조정
- ShopUI.cs 최적화 진행

- close #31 
- close #29 
- close #32 

---

### 🚀 주요 변경 내용

- 상점 페이지 번호가 출력되는 텍스트를 변경하여 첫 페이지가 1부터 시작되도록 구현
- ShopUI에서 판매 캐릭터 이미지에 SetNative를 적용하여 자연스럽게 출력되도록 구현

<img width="349" height="627" alt="image" src="https://github.com/user-attachments/assets/a718baff-0545-4349-8193-2f805ec3f3ef" />

- ShopUI.cs 인스펙터 창이 보기 쉽도록 코드를 작성
- 한 캐릭터에 대한 판매 정보를 출력할 때 사용되는 UI요소들을 Struct로 묶어서 작성

<img width="310" height="511" alt="image" src="https://github.com/user-attachments/assets/664cb994-726c-479e-9300-d7c4d56ef81c" />


---

### 💬 참고 사항

- ShopUI.cs에 대해 최적화가 부족한지 아닌지 평가해주시면 감사하겠습니다.

### ✅ Checklist (완료 조건)

- [x] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [x] 기획서의 내용을 준수했는가?
