### PR TITLE
bugFix : SettingsUI 소리 설정 오류 수정 완료

### DIFF
--- a/Assets/Scripts/Common/UI/SettingsUI.cs
+++ b/Assets/Scripts/Common/UI/SettingsUI.cs
@@ -19,12 +19,14 @@ public class SettingsUI : BaseUI
     public void OnBGMValueChanged()
     {
         AudioManager.Instance.SetVolume(AudioType.BGM, _bgmSlider.value);
+        UserDataManager.Instance.GetUserData<UserSettingsData>().BGMvalue = _bgmSlider.value;
         UserDataManager.Instance.SaveUserData();
     }
 
     public void OnSFXValueChanged()
     {
         AudioManager.Instance.SetVolume(AudioType.SFX, _sfxSlider.value);
+        UserDataManager.Instance.GetUserData<UserSettingsData>().SFXvalue = _sfxSlider.value;
         UserDataManager.Instance.SaveUserData();
     }
 


### PR DESCRIPTION
### 🔍 개요

- 소리를 설정하고 바꿔도 다시 설정하려고 SetttingsUI를 키면 UserData로 저장된 값으로 돌아가는 오류가 있었음. 소리를 바꿀 때, UserData에 저장하지 않아 생기는 문제. 이를 수정.

- close #30

---

### 🚀 주요 변경 내용

- 슬라이드 바를 움직여 소리를 설정하는 메소드에 UserData에 저장하는 코드를 추가.

---

### 💬 참고 사항

- 관련 GIF
![2025-09-29 11-12-31](https://github.com/user-attachments/assets/1c5ffdc4-8295-4b11-b97d-1727d0241a2a)

---

### ✅ Checklist (완료 조건)

- [X] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [X] 기획서의 내용을 준수했는가?
