### PR TITLE
feat : 일일미션 초기화 기능 구현 완료

### DIFF
--- a/Assets/Scripts/Common/UserData/UserAccountData.cs
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+using System;
+using System.Data;
+
+public class UserAccountData : IUserData
+{
+
+    public int accessDay { get; set; }
+    public int accessMonth {get; set; } 
+    public int accessYear { get; set; }   
+
+    public bool LoadData()
+    {
+        bool result = false;
+
+        accessDay = PlayerPrefs.GetInt(nameof(accessDay));
+        accessMonth = PlayerPrefs.GetInt(nameof(accessMonth));
+        accessYear = PlayerPrefs.GetInt(nameof(accessYear));
+
+        if (accessDay == 0 || accessMonth == 0 || accessYear == 0)
+        {
+            Debug.Log("접속 기록이 없습니다.");
+        }
+        else
+        {
+            Debug.Log($"현재 접속 시간 : {DateTime.Now.Year} : {DateTime.Now.Month} : {DateTime.Now.Day}");
+            Debug.Log($"지난 접속 시간 : {accessYear} : {accessMonth} : {accessDay}");
+
+            CheckAccessDays();
+
+            result = true;
+        }
+
+        return result;
+    }
+
+    public bool SaveData()
+    {
+        bool result = false;
+        try
+        {
+            PlayerPrefs.SetInt(nameof(accessDay), accessDay);
+            PlayerPrefs.SetInt(nameof(accessMonth), accessMonth);
+            PlayerPrefs.SetInt(nameof(accessYear), accessYear);
+            PlayerPrefs.Save();
+
+            result = true;
+
+            Debug.Log("접속 시간 저장 완료");
+        }
+        catch (Exception e)
+        {
+        }
+
+        return result;
+    }
+
+    public void SetDefaultData()
+    {
+        accessDay = DateTime.Now.Day;
+        accessMonth = DateTime.Now.Month;
+        accessYear = DateTime.Now.Year;
+
+        Debug.Log("초기 접속");
+
+        UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
+        SaveData();
+    }
+
+    
+
+    public void CheckAccessDays()
+    {
+        DateTime currentTime = new DateTime(accessYear, accessMonth, accessDay);
+        if (currentTime.Date < DateTime.Now.Date)
+        {
+            accessDay = DateTime.Now.Day;
+            accessMonth = DateTime.Now.Month;
+            accessYear = DateTime.Now.Year;
+
+            UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
+            SaveData();
+
+            Debug.Log("접속일이 변경되어 초기화됩니다.");
+        }
+
+    }
+
+}

--- a/Assets/Scripts/Common/UserData/UserAccountData.cs.meta
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 953cf51ae8731874aa15ba5285c82d34

--- a/Assets/Scripts/Common/UserData/UserAchievementData.cs
+++ b/Assets/Scripts/Common/UserData/UserAchievementData.cs
@@ -211,4 +211,20 @@ public class UserAchievementData : IUserData
 
         SaveData();
     }
+
+    public void ResetDailyMissionData()
+    {
+        TotalDailyMissionCleared = 0;
+        GotExtraDailyMissionReward = false;
+
+        TotalDayGameAccessed += 1;
+
+        // 일일미션 클리어 정보 초기화
+        clearedAchievements.RemoveWhere(id => id.StartsWith("DM_"));
+
+        /////////////////////////////
+        // 일일미션 관련 변수 초기화 //
+        /////////////////////////////
+
+    }
 }

--- a/Assets/Scripts/Common/UserData/UserDataManager.cs
+++ b/Assets/Scripts/Common/UserData/UserDataManager.cs
@@ -18,6 +18,7 @@ public class UserDataManager : SingletonBehaviour<UserDataManager>
         UserDataList.Add(new UserAchievementData());
         UserDataList.Add(new UserCurrencyData());
         UserDataList.Add(new UserCharacterData());
+        UserDataList.Add(new UserAccountData());
     }
 
     public void SetDefaultData()


### PR DESCRIPTION
### 🔍 개요

- 하루가 넘어간 후 게임에 접속할 때 일일미션이 초기화되도록 한다.

- close #41 

---

### 🚀 주요 변경 내용

- 접속 날짜에 대한 Load, Save, SetDefault 기능을 가진 UserAccountData.cs 추가
- UserDataManager에서 UserAccountData도 불러오게 구현
- 접속 날짜 데이터를 Load한 후, 현재 접속 날짜가 이전 접속 날짜보다 늦다면 UserAchievementData.cs에서 ResetDailyMissionData()를 실행하여 일일미션 초기화
- 미션 보상 획득 버튼을 누르면 미션 클리어 오브젝트가 활성화되게 구현


- 일일미션 초기화 기능 GIF
![Adobe Express - To-the-other-side-of-the-world - Lobby - Windows, Mac, Linux - Unity 6 2 (6000 2 1f1) _DX12_ 2025-10-02 00-01-57 (1)](https://github.com/user-attachments/assets/0091a343-5c32-4f67-9cd3-27a890d1b22f)


- 클리어 표시 기능 GIF
![Adobe Express - To-the-other-side-of-the-world - Title - Windows, Mac, Linux - Unity 6 2 (6000 2 1f1) _DX12_ 2025-10-02 00-32-01](https://github.com/user-attachments/assets/35ae5fb2-8137-4fcf-9b99-98a752da8c88)

---

### 💬 참고 사항

- **DailyMissionUI.cs**에 이미 일일미션 초기화 관련 코드가 있는데,
 일일미션 초기화 작업에 DailyMissionUI.cs의 **ResetDailyMissionClearCount**를 사용할 건지, 아니면 새로 만든 UserAchievementData의 **ResetDailyMissionData**를 사용할 것인지 고려해야 할 듯.
- 게임을 계속 켜둔 상태에서도 날짜가 지나면 일일미션이 초기화된 모습이 보여야 하는지? 그렇게 한다면 시간을 계속 체크해야 하는데, Update나 LateUpdate에서 구현이 될 것으로 예상되고, 리소스를 잡아먹을 가능성 있음

---

### ✅ Checklist (완료 조건)

- [x] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [x] 기획서의 내용을 준수했는가?
