### PR TITLE
feature : 일일미션 초기화기능 구현 및 클리어 표시 구현

### DIFF
--- a/Assets/Arts/드워프는 황금을 좋아해/4.GUI/Button/Background/UI_BG_C_1.png.meta
+++ b/Assets/Arts/드워프는 황금을 좋아해/4.GUI/Button/Background/UI_BG_C_1.png.meta
@@ -37,7 +37,7 @@ TextureImporter:
   maxTextureSize: 2048
   textureSettings:
     serializedVersion: 2
-    filterMode: 1
+    filterMode: 0
     aniso: 1
     mipBias: 0
     wrapU: 1

--- a/Assets/Prefabs/Lobby/DaliyMIssionUI.prefab
+++ b/Assets/Prefabs/Lobby/DaliyMIssionUI.prefab
@@ -986,33 +986,9 @@ PrefabInstance:
       value: DailyMissionUI_1
       objectReference: {fileID: 0}
     - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 2881165437454594297}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: OnClickMissionClear
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: DailyMissionUI, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1127,33 +1103,9 @@ PrefabInstance:
       value: DailyMissionUI_3
       objectReference: {fileID: 0}
     - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 2881165437454594297}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: OnClickMissionClear
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: DailyMissionUI, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1268,33 +1220,9 @@ PrefabInstance:
       value: DailyMissionUI_2
       objectReference: {fileID: 0}
     - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
       objectReference: {fileID: 2881165437454594297}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: OnClickMissionClear
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: DailyMissionUI, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 8760686620813957507, guid: 3325998f4fbe23748bbae0481c25196e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/Resources/UI/MissionUI.prefab
+++ b/Assets/Resources/UI/MissionUI.prefab
@@ -1,5 +1,143 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &407432053093280418
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7285533389146878405}
+  - component: {fileID: 7290081777613458045}
+  - component: {fileID: 3226786757530735601}
+  m_Layer: 5
+  m_Name: MissionNameText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7285533389146878405
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407432053093280418}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 347723112105530295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7290081777613458045
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407432053093280418}
+  m_CullTransparentMesh: 1
+--- !u!114 &3226786757530735601
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 407432053093280418}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'CLEAR
+
+'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 60f123f6d02643f49be214608480e601, type: 2}
+  m_sharedMaterial: {fileID: -7784642759686162230, guid: 60f123f6d02643f49be214608480e601, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 100
+  m_fontSizeBase: 100
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &3057176631653953200
 GameObject:
   m_ObjectHideFlags: 0
@@ -260,6 +398,18 @@ MonoBehaviour:
       - m_Target: {fileID: 4406141236559679710}
         m_TargetAssemblyTypeName: MissionUI, Assembly-CSharp
         m_MethodName: OnClickRewardButton
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: DailyMissionUI, Assembly-CSharp
+        m_MethodName: OnClickMissionClear
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -651,6 +801,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8054320991765982988}
+  - {fileID: 347723112105530295}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -677,7 +828,84 @@ MonoBehaviour:
   - {fileID: 1877635928073972767}
   - {fileID: 1481597205259167932}
   RewardAmountText: {fileID: 4688337659000229491}
+  GetRewardMarker: {fileID: 6584710707936620029}
   RewardButton: {fileID: 8760686620813957507}
+--- !u!1 &6584710707936620029
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 347723112105530295}
+  - component: {fileID: 6211617856318483641}
+  - component: {fileID: 34325496525859464}
+  m_Layer: 5
+  m_Name: GetRewardMarker
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &347723112105530295
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6584710707936620029}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7285533389146878405}
+  m_Father: {fileID: 3736546043565761090}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 900, y: 200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6211617856318483641
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6584710707936620029}
+  m_CullTransparentMesh: 1
+--- !u!114 &34325496525859464
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6584710707936620029}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.4811321, g: 0.4811321, b: 0.4811321, a: 0.87058824}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -2386756300528671995, guid: 0e7cd96fabfda95458f37e35ed435c7d, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 129.51
 --- !u!1 &7741364193102280576
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Common/UI/MissionUI.cs
+++ b/Assets/Scripts/Common/UI/MissionUI.cs
@@ -9,6 +9,7 @@ public class MissionUI : MonoBehaviour
     [SerializeField] private TextMeshProUGUI[] MissonNameText;
     [SerializeField] private TextMeshProUGUI[] MissionDescText;
     [SerializeField] private TextMeshProUGUI RewardAmountText;
+    [SerializeField] private GameObject GetRewardMarker;
 
     private AchievementModel missionData;
     [SerializeField] private Button RewardButton;
@@ -32,10 +33,13 @@ public class MissionUI : MonoBehaviour
 
         if (UserDataManager.Instance.GetUserData<UserAchievementData>().clearedAchievements.Contains(missionData.ID))
         {
+            GetRewardMarker.SetActive(true);
             RewardButton.interactable = false;
         }
         else
         {
+            GetRewardMarker.SetActive(false);
+
             if (missionData.TargetValue <= UserDataManager.Instance.GetUserData<UserAchievementData>().progress[missionData.ID])
                 RewardButton.interactable = true;
             else
@@ -76,6 +80,7 @@ public class MissionUI : MonoBehaviour
         UserDataManager.Instance.GetUserData<UserAchievementData>().clearedAchievements.Add(missionData.ID);
         UserDataManager.Instance.GetUserData<UserCurrencyData>().Gold += missionData.RewardGold;
         RewardButton.interactable = false;
+        GetRewardMarker.SetActive(true);
         UserDataManager.Instance.SaveUserData();
     }
 }

--- a/Assets/Scripts/Common/UserData/UserAccountData.cs
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs
@@ -1,0 +1,89 @@
+using UnityEngine;
+using System;
+using System.Data;
+
+public class UserAccountData : IUserData
+{
+
+    public int accessDay { get; set; }
+    public int accessMonth {get; set; } 
+    public int accessYear { get; set; }   
+
+    public bool LoadData()
+    {
+        bool result = false;
+
+        accessDay = PlayerPrefs.GetInt(nameof(accessDay));
+        accessMonth = PlayerPrefs.GetInt(nameof(accessMonth));
+        accessYear = PlayerPrefs.GetInt(nameof(accessYear));
+
+        if (accessDay == 0 || accessMonth == 0 || accessYear == 0)
+        {
+            Debug.Log("접속 기록이 없습니다.");
+        }
+        else
+        {
+            Debug.Log($"현재 접속 시간 : {DateTime.Now.Year} : {DateTime.Now.Month} : {DateTime.Now.Day}");
+            Debug.Log($"지난 접속 시간 : {accessYear} : {accessMonth} : {accessDay}");
+
+            CheckAccessDays();
+
+            result = true;
+        }
+
+        return result;
+    }
+
+    public bool SaveData()
+    {
+        bool result = false;
+        try
+        {
+            PlayerPrefs.SetInt(nameof(accessDay), accessDay);
+            PlayerPrefs.SetInt(nameof(accessMonth), accessMonth);
+            PlayerPrefs.SetInt(nameof(accessYear), accessYear);
+            PlayerPrefs.Save();
+
+            result = true;
+
+            Debug.Log("접속 시간 저장 완료");
+        }
+        catch (Exception e)
+        {
+        }
+
+        return result;
+    }
+
+    public void SetDefaultData()
+    {
+        accessDay = DateTime.Now.Day;
+        accessMonth = DateTime.Now.Month;
+        accessYear = DateTime.Now.Year;
+
+        Debug.Log("초기 접속");
+
+        UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
+        SaveData();
+    }
+
+    
+
+    public void CheckAccessDays()
+    {
+        DateTime currentTime = new DateTime(accessYear, accessMonth, accessDay);
+        if (currentTime.Date < DateTime.Now.Date)
+        {
+            accessDay = DateTime.Now.Day;
+            accessMonth = DateTime.Now.Month;
+            accessYear = DateTime.Now.Year;
+
+            UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
+            SaveData();
+
+            Debug.Log("접속일이 변경되어 초기화됩니다.");
+        }
+
+    }
+
+}

--- a/Assets/Scripts/Common/UserData/UserAccountData.cs
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs
@@ -29,6 +29,7 @@ public class UserAccountData : IUserData
         catch
         {
             Debug.Log("접속 기록이 없습니다.");
+            UserDataManager.Instance.GetUserData<UserAchievementData>().TotalDayGameAccessed = 0;
             SetDefaultData();
             return false;
         }
@@ -61,6 +62,7 @@ public class UserAccountData : IUserData
 
         Debug.Log("초기 접속");
 
+        UserDataManager.Instance.GetUserData<UserAchievementData>().IncreaseProgress("TotalDayGameAccessed", 1);
         UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
         SaveData();
     }
@@ -77,6 +79,7 @@ public class UserAccountData : IUserData
             accessYear = DateTime.Now.Year;
 
             UserDataManager.Instance.GetUserData<UserAchievementData>().ResetDailyMissionData();
+            UserDataManager.Instance.GetUserData<UserAchievementData>().IncreaseProgress("TotalDayGameAccessed", 1);
             SaveData();
 
             Debug.Log("접속일이 변경되어 초기화됩니다.");

--- a/Assets/Scripts/Common/UserData/UserAccountData.cs
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs
@@ -11,32 +11,31 @@ public class UserAccountData : IUserData
 
     public bool LoadData()
     {
-        bool result = false;
-
         accessDay = PlayerPrefs.GetInt(nameof(accessDay));
         accessMonth = PlayerPrefs.GetInt(nameof(accessMonth));
         accessYear = PlayerPrefs.GetInt(nameof(accessYear));
 
-        if (accessDay == 0 || accessMonth == 0 || accessYear == 0)
+        try
         {
-            Debug.Log("접속 기록이 없습니다.");
-        }
-        else
-        {
-            Debug.Log($"현재 접속 시간 : {DateTime.Now.Year} : {DateTime.Now.Month} : {DateTime.Now.Day}");
-            Debug.Log($"지난 접속 시간 : {accessYear} : {accessMonth} : {accessDay}");
+            // date 값 오류 체크용
+            var date = new DateTime(accessYear, accessMonth, accessDay);
+
+            Debug.Log($"현재 접속 날짜 : {DateTime.Now.Year} : {DateTime.Now.Month} : {DateTime.Now.Day}");
+            Debug.Log($"지난 접속 날짜 : {accessYear} : {accessMonth} : {accessDay}");
 
             CheckAccessDays();
-
-            result = true;
+            return true;
         }
-
-        return result;
+        catch
+        {
+            Debug.Log("접속 기록이 없습니다.");
+            SetDefaultData();
+            return false;
+        }
     }
 
     public bool SaveData()
     {
-        bool result = false;
         try
         {
             PlayerPrefs.SetInt(nameof(accessDay), accessDay);
@@ -44,15 +43,14 @@ public class UserAccountData : IUserData
             PlayerPrefs.SetInt(nameof(accessYear), accessYear);
             PlayerPrefs.Save();
 
-            result = true;
-
             Debug.Log("접속 시간 저장 완료");
+            return true;
         }
         catch (Exception e)
         {
+            Debug.Log("접속 시간 저장 실패..");
+            return false;
         }
-
-        return result;
     }
 
     public void SetDefaultData()

--- a/Assets/Scripts/Common/UserData/UserAccountData.cs.meta
+++ b/Assets/Scripts/Common/UserData/UserAccountData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 953cf51ae8731874aa15ba5285c82d34

--- a/Assets/Scripts/Common/UserData/UserAchievementData.cs
+++ b/Assets/Scripts/Common/UserData/UserAchievementData.cs
@@ -211,4 +211,20 @@ public class UserAchievementData : IUserData
 
         SaveData();
     }
+
+    public void ResetDailyMissionData()
+    {
+        TotalDailyMissionCleared = 0;
+        GotExtraDailyMissionReward = false;
+
+        TotalDayGameAccessed += 1;
+
+        // 일일미션 클리어 정보 초기화
+        clearedAchievements.RemoveWhere(id => id.StartsWith("DM_"));
+
+        /////////////////////////////
+        // 일일미션 관련 변수 초기화 //
+        /////////////////////////////
+
+    }
 }

--- a/Assets/Scripts/Common/UserData/UserDataManager.cs
+++ b/Assets/Scripts/Common/UserData/UserDataManager.cs
@@ -18,6 +18,7 @@ public class UserDataManager : SingletonBehaviour<UserDataManager>
         UserDataList.Add(new UserAchievementData());
         UserDataList.Add(new UserCurrencyData());
         UserDataList.Add(new UserCharacterData());
+        UserDataList.Add(new UserAccountData());
     }
 
     public void SetDefaultData()

--- a/Assets/Scripts/Lobby/LobbyManager.cs
+++ b/Assets/Scripts/Lobby/LobbyManager.cs
@@ -23,6 +23,5 @@ public class LobbyManager : SingletonBehaviour<LobbyManager>
         LobbyUIController.init();
         UIManager.Instance.CurrencyUI.SetActive(true);
         AudioManager.Instance.Play(AudioType.BGM, "lobby");
-        UserDataManager.Instance.GetUserData<UserAchievementData>().IncreaseProgress("TotalDayGameAccessed", 1);
     }
 }


### PR DESCRIPTION
### 🔍 개요

- 하루가 넘어간 후 게임에 접속할 때 일일미션이 초기화되도록 한다.
- 미션 클리어 보상 버튼을 클릭하면 클리어 표시가 생성된다. 또한 이미 클리어한 미션에도 클리어 표시가 생성된다.

- close #41 

---

### 🚀 주요 변경 내용

- 접속 날짜에 대한 Load, Save, SetDefault 기능을 가진 UserAccountData.cs 추가
- UserDataManager에서 UserAccountData도 불러오게 구현
- 접속 날짜 데이터를 Load한 후, 현재 접속 날짜가 이전 접속 날짜보다 늦다면 UserAchievementData.cs에서 ResetDailyMissionData()를 실행하여 일일미션 초기화
- 미션 보상 획득 버튼을 누르면 미션 클리어 오브젝트가 활성화되게 구현
- MissionUI prefab에 미션 클리어 오브젝트 "GetRewardMarker" 구현


- 일일미션 초기화 기능 GIF
![Adobe Express - To-the-other-side-of-the-world - Lobby - Windows, Mac, Linux - Unity 6 2 (6000 2 1f1) _DX12_ 2025-10-02 00-01-57 (1)](https://github.com/user-attachments/assets/0091a343-5c32-4f67-9cd3-27a890d1b22f)


- 클리어 표시 기능 GIF
![Adobe Express - To-the-other-side-of-the-world - Title - Windows, Mac, Linux - Unity 6 2 (6000 2 1f1) _DX12_ 2025-10-02 00-32-01](https://github.com/user-attachments/assets/35ae5fb2-8137-4fcf-9b99-98a752da8c88)

---

### 💬 참고 사항

- **DailyMissionUI.cs**에 이미 일일미션 초기화 관련 코드가 있는데,
 일일미션 초기화 작업에 DailyMissionUI.cs의 **ResetDailyMissionClearCount**를 사용할 건지, 아니면 새로 만든 UserAchievementData의 **ResetDailyMissionData**를 사용할 것인지 고려해야 할 듯.

---

### ✅ Checklist (완료 조건)

- [x] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [x] 기획서의 내용을 준수했는가?
