### PR TITLE
bugfix : 인게임 경고 효과음이 게임을 종료해도 재생되는 버그 해결

### DIFF
--- a/Assets/Scripts/Common/UI/PauseUI.cs
+++ b/Assets/Scripts/Common/UI/PauseUI.cs
@@ -13,8 +13,11 @@ public class PauseUI : SettingsUI
     public void OnClickExitBtn()
     {
         Debug.Log("게임 플레이를 종료합니다.");
+        AudioManager.Instance.StopAll();
+
         var frontUI = UIManager.Instance.GetFrontUI();
         if (frontUI != null) frontUI.Close();
+
         SceneLoader.Instance.LoadSceneAsync(ESceneType.Lobby);
     }
 
@@ -22,8 +25,10 @@ public class PauseUI : SettingsUI
     {
         Debug.Log("게임을 재시작합니다.");
         AudioManager.Instance.StopAll();
+
         var frontUI = UIManager.Instance.GetFrontUI();
         if (frontUI != null) frontUI.Close();
+
         SceneLoader.Instance.ReloadScene();
     }
 


### PR DESCRIPTION
### 🔍 개요
- 인게임에서 경고 SFX가 재생될 때 로비로 이동하는 버튼을 눌렀을 때 오디오가 정지되도록 구현한다.
#69 
---

### 🚀 주요 변경 내용

- PauseUI.cs에서 재시작 버튼을 눌렀을 때 모든 오디오가 초기화되도록 구현

---

### 💬 참고 사항


https://github.com/user-attachments/assets/9e66ba05-2240-47e0-b447-0439c14a8af4



### ✅ Checklist (완료 조건)

- [X] Reviewers / Assignees / Labels / Milestone 지정 완료했는가?
- [X] 기획서의 내용을 준수했는가?